### PR TITLE
do not read ~/.psqlrc in check_replication_lag.pl

### DIFF
--- a/bin/check_replication_lag.pl
+++ b/bin/check_replication_lag.pl
@@ -8,19 +8,19 @@ my $REPLICA_DB=$ARGV[1] or die "call syntax $0 masterdb slavedb";
 my $CRON=$ARGV[2];
 my $CRON_LIMIT=$ARGV[3];
 
-my $replica_pos = `psql -t -h $REPLICA_DB -c 'SELECT pg_last_xlog_receive_location()'`;
-my $master_pos = `psql -t -h $MASTER_DB -c 'SELECT pg_current_xlog_location()'`;
+my $replica_pos = `psql -X -t -h $REPLICA_DB -c 'SELECT pg_last_xlog_receive_location()'`;
+my $master_pos = `psql -X -t -h $MASTER_DB -c 'SELECT pg_current_xlog_location()'`;
 $master_pos =~ s/^\s*(\S+)\s*$/$1/;
 $replica_pos =~ s/^\s*(\S+)\s*$/$1/;
 
 my $replay_delay = CalculateNumericalOffset($master_pos) - CalculateNumericalOffset($replica_pos);
 
 if ($CRON and $CRON_LIMIT) {
-	if ($replay_delay > $CRON_LIMIT) {
-		print "ERROR: replication lag $MASTER_DB -> $REPLICA_DB is $replay_delay bytes\n";
-	}
+    if ($replay_delay > $CRON_LIMIT) {
+        print "ERROR: replication lag $MASTER_DB -> $REPLICA_DB is $replay_delay bytes\n";
+    }
 } else {
-	print "$replay_delay\n";
+    print "$replay_delay\n";
 }
 
 
@@ -34,4 +34,3 @@ sub CalculateNumericalOffset
     # First part is logid, second part is record offset
     return (hex("ffffffff") * hex($pieces[0])) + hex($pieces[1]);
 }
-


### PR DESCRIPTION
.psqlrc may write some messages to stdout like "Timing is on." and corrupt CalculateNumericalOffset function logic

PS: and my editor replaced \t to spaces for consistency style