### PR TITLE
sql/global_reports/query_stat_total variant for postgresql 18

### DIFF
--- a/sql/global_reports/query_stat_total_18.sql
+++ b/sql/global_reports/query_stat_total_18.sql
@@ -1,0 +1,1 @@
+query_stat_total_17.sql


### PR DESCRIPTION
There are no functional changes compared to PostgreSQL 17 version, so just a symlink.

I'm not sure if it will be okay now if I push the commit directly, so I'll propose it via a pull request.